### PR TITLE
Prune Imports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2021-9-30 Marius Barth   <marius.barth@uni-koeln.de>
+      * DESCRIPTION: removed the Hmisc package from Imports field
+      * NAMESPACE: Do not import wtd.var from Hmisc, anymore
+      * R/Hmisc-package.R: added a copy of function wtd.var from Hmisc package
+
 2020-7-27 Yu-Sung Su     <suyusung@tsinghua.edu.cn>
       * DESCRIPTION: (Version, Date): 1.11.2
       * NAMESPACE: import weighted.mean from stats and wtd.var from Hmisc
@@ -12,7 +17,7 @@
 2018-4-12 Yu-Sung Su     <suyusung@tsinghua.edu.cn>
       * DESCRIPTION: (Version, Date): 1.10.1
       * R/bayesglm: fix a bug where scale=TRUE the prior.scale miscount the nvars.
-      * R/sim.glm: improve the speed.  
+      * R/sim.glm: improve the speed.
       * man/standardized: fix a typo in the example
 
 2016-11-24 Yu-Sung Su     <suyusung@tsinghua.edu.cn>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Author: Andrew Gelman [aut],
 Maintainer: Yu-Sung Su <suyusung@tsinghua.edu.cn>
 BugReports: https://github.com/suyusung/arm/issues/
 Depends: R (>= 3.1.0), MASS, Matrix (>= 1.0), stats, lme4 (>= 1.0)
-Imports: abind, coda, graphics, grDevices, Hmisc, methods, nlme, utils
+Imports: abind, coda, graphics, grDevices, methods, nlme, utils
 Description: Functions to accompany A. Gelman and J. Hill, Data Analysis Using Regression and Multilevel/Hierarchical Models, Cambridge University Press, 2007.
 License: GPL (> 2)
 URL: https://CRAN.R-project.org/package=arm

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,10 +14,6 @@ importFrom(graphics,
     "text",
     "title")
 
-importFrom(Hmisc,
-    "wtd.var")
-
-
 importFrom(grDevices,
     "gray",
     "heat.colors",

--- a/R/Hmisc-package.R
+++ b/R/Hmisc-package.R
@@ -1,0 +1,34 @@
+# This function is a direct copy from the 'Hmisc' package by Frank Harrell
+#
+# Authors:
+# Frank Harrell
+# Department of Biostatistics
+# Vanderbilt University School of Medicine
+# fh@fharrell.com
+# Benjamin Tyner
+# btyner@gmail.com
+
+
+wtd.var <- function (x, weights = NULL, normwt = FALSE, na.rm = TRUE, method = c("unbiased", "ML"))
+{
+  method <- match.arg(method)
+  if (!length(weights)) {
+    if (na.rm)
+      x <- x[!is.na(x)]
+    return(var(x))
+  }
+  if (na.rm) {
+    s <- !is.na(x + weights)
+    x <- x[s]
+    weights <- weights[s]
+  }
+  if (normwt)
+    weights <- weights * length(x)/sum(weights)
+  if (normwt || method == "ML")
+    return(as.numeric(stats::cov.wt(cbind(x), weights, method = method)$cov))
+  sw <- sum(weights)
+  if (sw <= 1)
+    warning("only one effective observation; variance estimate undefined")
+  xbar <- sum(weights * x)/sw
+  sum(weights * ((x - xbar)^2))/(sw - 1)
+}


### PR DESCRIPTION
Hi @suyusung,

thank you very much for this awesome package! I am opening this PR because it is the critical node in the dependency graph of multiple R packages that I rely on. For instance, the MBESS package, which is heavily used by psychologists to calculate confidence intervals for estimates of effects sizes, has the following recursive imports:
```
MBESS -> sem -> mi -> arm -> Hmisc -> foreign
```
Basically, a variety of packages implementing statistical procedures (MBESS, sem, mi, arm) rely on a package that is intended to import non-standard data files (foreign). The problem in my case is that my CI breaks because foreign is not available on specific platform/R version combinations, which prohibits testing my packages on, for instance, the oldrel of R.

I assumed because arm imports only one function from Hmisc, it is worth a try.
