### PR TITLE
State implicit Matrix version requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Author: Andrew Gelman [aut],
   Vincent Dorie [ctb]
 Maintainer: Yu-Sung Su <suyusung@tsinghua.edu.cn> 
 BugReports: https://github.com/suyusung/arm/issues/
-Depends: R (>= 3.1.0), MASS, Matrix (>= 1.0), stats, lme4 (>= 1.0)
+Depends: R (>= 3.1.0), MASS, Matrix (>= 1.6-1.1), stats, lme4 (>= 1.0)
 Imports: abind, coda, graphics, grDevices, methods, nlme, utils
 Description: Functions to accompany A. Gelman and J. Hill, Data Analysis Using Regression and Multilevel/Hierarchical Models, Cambridge University Press, 2007.
 License: GPL (> 2)


### PR DESCRIPTION
`crossprod()` + `tcrossprod()` are only recently exported by {Matrix}:

https://github.com/suyusung/arm/blob/f50e07a940eca15c3732b36dd9162cbc862104cd/NAMESPACE#L38-L45

https://github.com/cran/Matrix/commit/903f6a8f2bc94ce01d8581f62b9d80a46fc19474